### PR TITLE
GTM to set CD before pageview

### DIFF
--- a/js/ab-test.js
+++ b/js/ab-test.js
@@ -1,7 +1,5 @@
 $.fn.ABTest = function(total, show){
 	
-	console.log("A/B Test hit", total, show);
-	
 	for (i = 1; i <= total; i++) { 
 		 if (i != show){
 			$(".abtestV" + i).remove();	

--- a/js/ab-test.js
+++ b/js/ab-test.js
@@ -1,16 +1,13 @@
-$.fn.ABTest = function(total){
+$.fn.ABTest = function(total, show){
 	
-	show = Math.floor((Math.random() * total) + 1);
+	console.log("A/B Test hit", total, show);
+	
 	for (i = 1; i <= total; i++) { 
 		 if (i != show){
 			$(".abtestV" + i).remove();	
 		}else{
 			$(".abtestV" + i).removeClass("hide");	
 		}
-	}
-
-	if(typeof ga !== "undefined"){
-		ga('set', 'dimension1', 'variation ' + show);
 	}
 	
 }

--- a/xsl/above-analytics.xsl
+++ b/xsl/above-analytics.xsl
@@ -1,0 +1,8 @@
+<!-- place this code before your google tag manager code -->
+<xsl:if test="ouc:div/table[@class='ou-abtest']">
+    <script>
+        var abtestTotal = <xsl:value-of select="count(ouc:div/table[@class='ou-abtest']/tbody/tr)" />;
+        var abtestRandom = Math.floor((Math.random() * abtestTotal) + 1);
+        var abtest= 'variation ' + abtestRandom;
+    </script>
+</xsl:if>

--- a/xsl/above-analytics.xsl
+++ b/xsl/above-analytics.xsl
@@ -2,7 +2,6 @@
 <xsl:if test="ouc:div/table[@class='ou-abtest']">
     <script>
         var abtestTotal = <xsl:value-of select="count(ouc:div/table[@class='ou-abtest']/tbody/tr)" />;
-        var abtestRandom = Math.floor((Math.random() * abtestTotal) + 1);
-        var abtest= 'variation ' + abtestRandom;
+        var abtest = Math.floor((Math.random() * abtestTotal) + 1);
     </script>
 </xsl:if>

--- a/xsl/snippet-abtest.xsl
+++ b/xsl/snippet-abtest.xsl
@@ -23,7 +23,7 @@ Last Updated: 1/19/18
         </xsl:for-each>
     	
         <script src="../js/abtest.js"></script>
-        <script>$(this).ABTest(abtestTotal, abtestRandom);</script>
+        <script>$(this).ABTest(abtestTotal, abtest);</script>
 		
     </xsl:template>
 	

--- a/xsl/snippet-abtest.xsl
+++ b/xsl/snippet-abtest.xsl
@@ -4,7 +4,7 @@
 Implementations Skeletor v3 - 5/10/2014
 
 Contributors: Jesse Clark <jesse.clark@unco.edu>
-Last Updated: 1/16/18
+Last Updated: 1/19/17
 -->
 <xsl:stylesheet version="3.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -16,15 +16,14 @@ Last Updated: 1/16/18
     
     <!-- Asset for A/B Testing -->
 	<xsl:template match="table[@class='ou-abtest']">
-    
     	<xsl:for-each select="tbody/tr">
         	<div class="abtestV{position()} hide">
             	<xsl:apply-templates select="td[1]" />
             </div>
         </xsl:for-each>
     	
-        <script src="..js/abtest.js"></script>
-        <script>$(this).ABTest(<xsl:value-of select="count(tbody/tr)" />);</script>
+        <script src="http://www.unco.edu/_resources/js/abtest.js"></script>
+        <script>$(this).ABTest(abtestTotal, abtestRandom);</script>
 		
     </xsl:template>
 	

--- a/xsl/snippet-abtest.xsl
+++ b/xsl/snippet-abtest.xsl
@@ -4,7 +4,7 @@
 Implementations Skeletor v3 - 5/10/2014
 
 Contributors: Jesse Clark <jesse.clark@unco.edu>
-Last Updated: 1/19/17
+Last Updated: 1/19/18
 -->
 <xsl:stylesheet version="3.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -22,7 +22,7 @@ Last Updated: 1/19/17
             </div>
         </xsl:for-each>
     	
-        <script src="http://www.unco.edu/_resources/js/abtest.js"></script>
+        <script src="../js/abtest.js"></script>
         <script>$(this).ABTest(abtestTotal, abtestRandom);</script>
 		
     </xsl:template>


### PR DESCRIPTION
Use Google Tag Manager and a different approach to setting Custom Dimension.

A variable named abtest is set prior to the GTM code. Then GTM looks for that variable and sets it behind the scenes. 

This is a proposed fix for issue #1.